### PR TITLE
use UTF-8 charset in www/view.html

### DIFF
--- a/www/view.html
+++ b/www/view.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Teleprompter</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <script src="/vendor/eventsource.js"></script>
     <script src="/vendor/fetch.js"></script>
     <script src="/vendor/fastclick.js"></script>


### PR DESCRIPTION
resolves #3 

To fix the issue, I added `charset="UTF-8"` to the `<meta>` tag in `www/view.html`

With this change, languages such as Japanese and Korean render properly in the viewer.

Please review and merge if you like the changes.  If you would like me to revise this pull request, let me know and I can make modifications :)

Thanks for making this tool! 😄 

**Screenshot**
![image](https://user-images.githubusercontent.com/3689811/36026217-2d8736d4-0d3a-11e8-9ffc-371dbee548f9.png)
